### PR TITLE
Add fix for libcrypto error in FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,7 @@ You can now find the compiled version of Aseprite in the `output/aseprite/build/
 ## FAQ
 If you get the following error when running Aseprite: `./aseprite: error while loading shared libraries: libdeflate.so.0: cannot open shared object file: No such file or directory`, make sure you have libdeflate installed on your system. Please run
 `sudo apt install -y libdeflate0 libdeflate-dev`
+
+If you get the following error: `./aseprite: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory`, you'll want to install the OpenSSL 1.1 package/library. You may have only OpenSSL 3.x installed, meanwhile Aseprite still uses the v1.1 library.
+* On Arch / Arch based distros, run `sudo pacman -Syu openssl-1.1`
+* On Ubuntu try: `sudo apt install -y libssl1.1`


### PR DESCRIPTION
Closes #7 

I've also included a fix that should hopefully work for Ubuntu, for the case that Aseprite still uses libssl1.1 while new installations of Ubuntu stopped shipping libssl1.1 by default (unsure if this is actually the case but it doesn't hurt to add it)