### PR TITLE
Add non-compose support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,14 @@
+IMAGE_NAME := docker-aseprite
+
+build: build-image
+	docker run --rm \
+	-v ${PWD}/output:/output \
+	-v ${PWD}/dependencies:/dependencies \
+	${IMAGE_NAME}
+
+build-compose:
+	docker-compose build
+	docker-compose up
+
+build-image:
+	docker build -t ${IMAGE_NAME} .

--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@ If any of the folders of the projects folder isn't empty, the script will skip c
  * Install docker
  * Clone this repository 
  * cd into cloned repository
- * Run `docker-compose build`
- * Run `docker-compose up`
+ * Run `make build` or `make build-compose` (The latter will use docker-compose to build the image)
  * Grab a cup of coffee, since this can take quite a while (Compiling build deps, skia, and aseprite)
 
 You can now find the compiled version of Aseprite in the `output/aseprite/build/bin` folder


### PR DESCRIPTION
docker-compose (v1) is not super easy to use anymore on Docker (volume mounting and like, having to flag v1 docker-compose style on latest docker desktop, etc)

So, this moves the two build commands to a Makefile, and you can build it now with a docker run directive.