### PR TITLE
Improvements to Dockerfile, build script, and configuration for Aseprite compilation

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "sarif-viewer.connectToGithubCodeScanning": "off"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,55 @@
-FROM python
+FROM python:3.12-slim-trixie
 
-#Required for tzdata
-ENV TZ=Europe/Amsterdam
+ARG TZ=America/Los_Angeles
+ARG LANG=C.UTF-8
+ARG AESCOMPILE_ASEPRITE_VERSION=v1.3.15.2
+ARG AESCOMPILE_SKIA_VERSION=aseprite-m124
+ARG AESCOMPILE_DEPENDENCIES_DIR=/dependencies
+ARG AESCOMPILE_OUTPUT_DIR=/output
+ARG AESCOMPILE_BUILD_TYPE=RelWithDebInfo
+ARG AESCOMPILE_VERBOSITY=3
+ARG AESCOMPILE_NO_COLOR=false
+ARG AESCOMPILE_QUIET=false
+
+ENV DEBIAN_FRONTEND=noninteractive
+ENV LANG=${LANG}
+ENV LC_ALL=${LANG}
+ENV TZ=${TZ}
+ENV PIP_NO_CACHE_DIR=1
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_ROOT_USER_ACTION=ignore
+ENV AESCOMPILE_ASEPRITE_VERSION=${AESCOMPILE_ASEPRITE_VERSION:-v1.3.15.2}
+ENV AESCOMPILE_SKIA_VERSION=${AESCOMPILE_SKIA_VERSION:-aseprite-m124}
+ENV AESCOMPILE_DEPENDENCIES_DIR=${AESCOMPILE_DEPENDENCIES_DIR:-/dependencies}
+ENV AESCOMPILE_OUTPUT_DIR=${AESCOMPILE_OUTPUT_DIR:-/output}
+ENV AESCOMPILE_BUILD_TYPE=${AESCOMPILE_BUILD_TYPE:-RelWithDebInfo}
+ENV AESCOMPILE_VERBOSITY=${AESCOMPILE_VERBOSITY:-3}
+ENV AESCOMPILE_NO_COLOR=${AESCOMPILE_NO_COLOR:-false}
+ENV AESCOMPILE_QUIET=${AESCOMPILE_QUIET:-false}
+
+# Set timezone
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Install dependencies
-RUN apt-get update
-RUN apt-get upgrade -y
-RUN apt-get install -y git unzip curl build-essential cmake ninja-build libx11-dev libxcursor-dev libxi-dev libgl1-mesa-dev libfontconfig1-dev
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+    git \
+    unzip \
+    curl \
+    build-essential \
+    g++ \
+    clang \
+    cmake \
+    ninja-build \
+    libx11-dev \
+    libxcursor-dev \
+    libxi-dev \
+    libxrandr-dev \
+    libgl1-mesa-dev \
+    libfontconfig1-dev && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 COPY compile.sh /
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 nilsve
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,15 @@
 IMAGE_NAME := docker-aseprite
 
+.PHONY: build build-compose build-image clean
+
+clean:
+	sudo rm -rf ./output ./dependencies 2>/dev/null || true
+
 build: build-image
-	docker run --rm \
+	docker run -it --rm \
 	-v ${PWD}/output:/output \
 	-v ${PWD}/dependencies:/dependencies \
-	${IMAGE_NAME}
+	${IMAGE_NAME} $(ARGS)
 
 build-compose:
 	docker-compose build

--- a/README.md
+++ b/README.md
@@ -79,15 +79,6 @@ make build ARGS="-vvv --no-color"  # Clean debug output without colors
 make build ARGS="--help"
 ```
 
-### Advanced Features
-
-- **Real-time Output**: Command output appears immediately with proper stream separation
-- **OpenSSL Auto-detection**: Automatically finds and configures OpenSSL for compilation
-- **PATH Management**: Safe PATH modifications with automatic restoration on exit
-- **Error Recovery**: Comprehensive error trapping with detailed failure information
-- **ANSI Cleaning**: Removes terminal escape sequences for clean log output
-- **Smart Output Classification**: Automatically categorizes command output as info/warning/error
-
 ### Build Types
 
 - **RelWithDebInfo** (default): Optimized build with debug information included

--- a/README.md
+++ b/README.md
@@ -2,52 +2,107 @@
 
 This repository allows you to compile Aseprite without installing any build tools. All that is required is Docker.
 
-After spending hours trying to get Aseprite to compile, I decided to just make a Docker image for it 
+After spending hours trying to get Aseprite to compile, I decided to just make a Docker image for it.
 
-Currently the script checks out Skia version `m124` and Aseprite version `1.3.15.2`. You can easily change this in `compile.sh` by changing the `-b` flag to the desired versions.
+The script features a comprehensive logging system with robust error handling, and fully configurable build options. By default it compiles Skia version `aseprite-m124` and Aseprite version `v1.3.15.2` with `RelWithDebInfo` build type.
 
-If any of the folders of the projects folder isn't empty, the script will skip checking out the latest versions. In order to re-download, delete the according folder.
+If any of the folders of the projects folder isn't empty, the script will skip checking out the latest versions. In order to re-download, delete the according folder:
 * ./dependencies/depot_tools
 * ./dependencies/skia
-* ./output/aseprite
+* ./dependencies/aseprite
 
 ## Usage
- * Install docker
- * Clone this repository 
- * cd into cloned repository
- * Run `make build` or `make build-compose` (The latter will use docker-compose to build the image)
- * Grab a cup of coffee, since this can take quite a while (Compiling build deps, skia, and aseprite)
 
-You can now find the compiled version of Aseprite in the `output/aseprite/build/bin` folder
+### Quick Start
+1. Install docker
+2. Clone this repository 
+3. cd into cloned repository
+4. Run `make build` (uses default settings)
+5. Grab a cup of coffee, since this can take quite a while (Compiling build deps, skia, and aseprite)
+
+You can now find the compiled version of Aseprite in the `output/bin` folder (or just `output/aseprite` if bin folder doesn't exist)
+
+### Advanced Usage
+
+The compilation script supports various options that can be passed through the Makefile.
+
+```bash
+# Basic usage with default settings
+make build
+
+# Using docker-compose (alternative method)
+make build-compose
+
+# Pass arguments to the compilation script
+make build ARGS="[OPTIONS]"
+```
+
+### Available Options
+
+| Command Line Option | Environment Variable | Description |
+|---------------------|---------------------|-------------|
+| `-a, --aseprite-version VERSION` | `AESCOMPILE_ASEPRITE_VERSION` | Set Aseprite version (default: v1.3.15.2) |
+| `-s, --skia-version VERSION` | `AESCOMPILE_SKIA_VERSION` | Set Skia version (default: aseprite-m124) |
+| `-d, --dependencies-dir DIR` | `AESCOMPILE_DEPENDENCIES_DIR` | Set dependencies directory (default: /dependencies) |
+| `-o, --output-dir DIR` | `AESCOMPILE_OUTPUT_DIR` | Set output directory (default: /output) |
+| `-b, --build-type TYPE` | `AESCOMPILE_BUILD_TYPE` | CMake build type: `Release` or `RelWithDebInfo` (default: RelWithDebInfo) |
+| `-v, --verbose` | `AESCOMPILE_VERBOSITY` | Increase verbosity (0=critical, 1=error, 2=warning, 3=info, 4=debug) |
+| `-q, --quiet` | `AESCOMPILE_QUIET` | Suppress output except errors and critical messages |
+| `-n, --no-color` | `AESCOMPILE_NO_COLOR` | Disable colored output and emojis |
+| `-h, --help` | N/A | Display help message and exit |
+
+### Examples
+
+```bash
+# Basic compilation with default settings
+make build
+
+# Compile specific versions with verbose output
+make build ARGS="-a v1.3.15.2 -s aseprite-m124 -v"
+
+# Compile older versions
+make build ARGS="--aseprite-version v1.3.10 --skia-version aseprite-m102"
+
+# Use custom directories (mapped to host paths via Docker volumes)
+make build ARGS="-d /custom/deps -o /custom/output"
+
+# Release build without debug info, no colors/emojis, quiet mode
+make build ARGS="-b Release --no-color --quiet"
+
+# Maximum verbosity for debugging (shows debug, info, warning, error, critical)
+make build ARGS="-vvvv"
+
+# Debug mode with real-time output processing
+make build ARGS="-vvv --no-color"  # Clean debug output without colors
+
+# Show comprehensive help with all options
+make build ARGS="--help"
+```
+
+### Advanced Features
+
+- **Real-time Output**: Command output appears immediately with proper stream separation
+- **OpenSSL Auto-detection**: Automatically finds and configures OpenSSL for compilation
+- **PATH Management**: Safe PATH modifications with automatic restoration on exit
+- **Error Recovery**: Comprehensive error trapping with detailed failure information
+- **ANSI Cleaning**: Removes terminal escape sequences for clean log output
+- **Smart Output Classification**: Automatically categorizes command output as info/warning/error
+
+### Build Types
+
+- **RelWithDebInfo** (default): Optimized build with debug information included
+* **Release**: Fully optimized build without debug information (smaller binary)
 
 ## FAQ
+
 If you get the following error when running Aseprite: `./aseprite: error while loading shared libraries: libdeflate.so.0: cannot open shared object file: No such file or directory`, make sure you have libdeflate installed on your system. Please run
 `sudo apt install -y libdeflate0 libdeflate-dev`
 
 If you get the following error: `./aseprite: error while loading shared libraries: libcrypto.so.1.1: cannot open shared object file: No such file or directory`, you'll want to install the OpenSSL 1.1 package/library. You may have only OpenSSL 3.x installed, meanwhile Aseprite still uses the v1.1 library.
+
 * On Arch / Arch based distros, run `sudo pacman -Syu openssl-1.1`
 * On Ubuntu try: `sudo apt install -y libssl1.1`
 
 ## License
 
-MIT License
-
-Copyright (c) 2025 nilsve
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.

--- a/compile.sh
+++ b/compile.sh
@@ -191,7 +191,7 @@ trap '__cleanup "normal"' EXIT
 # Main() ########################
 [[ ! "${BASH_SOURCE[0]}" == "${0}" ]] && return 0
 __parse "$@"
-__log "info" "Using Aseprite version: ${AESCOMPILE_ASEPRITE_VERSION}"
+__log "info" "Building Aseprite version: ${AESCOMPILE_ASEPRITE_VERSION} (${AESCOMPILE_BUILD_TYPE})"
 __log "info" "Using Skia version: ${AESCOMPILE_SKIA_VERSION}"
 
 cd "${AESCOMPILE_DEPENDENCIES_DIR}"

--- a/compile.sh
+++ b/compile.sh
@@ -1,80 +1,254 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
-# Fail on errors
-set -e
+AESCOMPILE_ASEPRITE_VERSION=${AESCOMPILE_ASEPRITE_VERSION:-v1.3.15.2}
+AESCOMPILE_SKIA_VERSION=${AESCOMPILE_SKIA_VERSION:-aseprite-m124}
+AESCOMPILE_DEPENDENCIES_DIR=${AESCOMPILE_DEPENDENCIES_DIR:-/dependencies}
+AESCOMPILE_OUTPUT_DIR=${AESCOMPILE_OUTPUT_DIR:-/output}
+AESCOMPILE_BUILD_TYPE=${AESCOMPILE_BUILD_TYPE:-RelWithDebInfo}
+AESCOMPILE_VERBOSITY=${AESCOMPILE_VERBOSITY:-3}
+AESCOMPILE_NO_COLOR=${AESCOMPILE_NO_COLOR:-false}
+AESCOMPILE_QUIET=${AESCOMPILE_QUIET:-false}
 
-ASEPRITE_VERSION=v1.3.15.2
-SKIA_VERSION=aseprite-m124
+AESCOMPILE_ORIGINAL_PATH="$PATH"
+C_RED=$(tput setaf 1); C_GREEN=$(tput setaf 2); C_YELLOW=$(tput setaf 3); C_MAGENTA=$(tput setaf 5); C_CYAN=$(tput setaf 6); C_BOLD=$(tput bold); C_RESET=$(tput sgr0)
+declare -A LOG_CONFIG=(["debug"]="0:$C_CYAN:🔍" ["info"]="1:$C_GREEN:ℹ️" ["warning"]="2:$C_YELLOW:⚠️" ["error"]="3:$C_RED:❌" ["critical"]="4:$C_MAGENTA:🚨")
 
-echo "Download and compile Skia & other dependencies"
-cd /dependencies
+__log() {
+    local l m c n t r u e
+    l="$1"; shift; m="$*"; c="${LOG_CONFIG[$l]}"
+    [[ -z "$c" ]] && return 1
+    n="${c%%:*}"; r="${c#*:}"; r="${r%%:*}"; e="${c##*:}"
+    [[ $n -lt $((4 - AESCOMPILE_VERBOSITY)) ]] && return 0
+    [[ "$AESCOMPILE_QUIET" == "true" && "$l" != "error" && "$l" != "critical" ]] && return 0
+    t=$(date '+%Y-%m-%d %H:%M:%S'); c=""
+    u=$(echo "$l" | tr '[:lower:]' '[:upper:]')
+    if [[ "$AESCOMPILE_NO_COLOR" == "false" ]]; then 
+        c="$C_RESET"
+        printf "%s[%s] %s%s  %-8s%s %s\n" "$r" "$t" "$r" "$e" "$u" "$c" "$m"
+    else 
+        r=""
+        printf "[%s] %-8s %s\n" "$t" "$u" "$m"
+    fi
+}
 
-if [ ! -d "/dependencies/depot_tools" ]
-then
-  echo "Cloning depot_tools"
-  git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
-  cd depot_tools
-  git checkout main
-  cd ..
+__add_path() {
+    local p="$1"
+    [[ -z "$p" || ! -d "$p" ]] && return 1
+    [[ ":$PATH:" != *":$p:"* ]] && PATH="$p:$PATH"
+    __log "debug" "Added to PATH: $p"
+}
+
+__rm_path() {
+    local p="$1" n
+    [[ -z "$p" ]] && return 1
+    n=$(echo ":$PATH:" | sed "s|:$p:|:|g" | sed 's/^://;s/:$//')
+    [[ "$PATH" != "$n" ]] && { PATH="$n"; __log "debug" "Removed from PATH: $p"; }
+}
+
+__find_openssl() {
+    local d dirs=("/usr" "/usr/local" "/opt/homebrew" "/usr/local/opt/openssl@1.1" "/usr/local/opt/openssl@3" "/usr/local/ssl")
+    for d in "${dirs[@]}"; do
+        if [[ -f "$d/include/openssl/opensslv.h" && (-f "$d/lib/libssl.so" || -f "$d/lib/libssl.a" || -f "$d/lib/libssl.dylib") ]]; then
+            __log "debug" "Found OpenSSL at: $d"
+            echo "$d"
+            return 0
+        fi
+    done
+    __log "warning" "OpenSSL not found in standard locations"
+    return 1
+}
+
+__strip_line() {
+    local line="$1"
+    line=$(echo "$line" | sed -E 's/\x1b\[[0-9;]*[a-zA-Z]//g' | sed 's/\x1b\[[0-9]*m//g' | tr -cd '[:print:][:space:]' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+    echo "$line"
+}
+
+__process_output() {
+    local f
+    f="$1"
+    while IFS= read -r line; do
+        if [[ -n "$line" ]]; then
+            local l m
+            l=$(__strip_line "$line")
+            m=$(echo "$l" | tr '[:upper:]' '[:lower:]')
+            if [[ "$m" == *"error:"* || "$m" == *"err:"* || "$m" == *"fatal:"* || "$m" == *"failed:"* || "$m" == *"fail:"* ]]; then
+                __log "error" "$l"
+            elif [[ "$m" == *"warning:"* || "$m" == *"warn:"* ]]; then
+                __log "warning" "$l"
+            else
+                __log "debug" "$l"
+            fi
+        fi
+    done < "$f"
+}
+
+__cmd() {
+    local c o e p q x
+    c="$*"; o="/tmp/cmd_stdout_$$"; e="/tmp/cmd_stderr_$$"
+    __log "debug" "Executing command: $c"
+    mkfifo "$o" "$e"
+    __process_output "$o" &
+    p=$!
+    __process_output "$e" &
+    q=$!
+    eval "$c" > "$o" 2> "$e"
+    x=$?
+    wait $p $q
+    rm -f "$o" "$e"
+    return $x
+}
+
+__cleanup() {
+    local e r s f
+    e=$?; r="${1:-normal}"; s="/tmp/compile_stderr_$$"; f=("$s" "/tmp/compile_*.$$" "/tmp/cmd_stdout_$$" "/tmp/cmd_stderr_$$")
+    [[ "$PATH" != "$AESCOMPILE_ORIGINAL_PATH" ]] && { PATH="$AESCOMPILE_ORIGINAL_PATH"; __log "debug" "Restored original PATH"; }
+    for p in "${f[@]}"; do rm -f $p 2>/dev/null || true; done
+    case "$r" in
+        "error") __log "debug" "Cleanup completed after error (exit code: $e)" ;;
+        "interrupt") __log "warning" "Script interrupted by user, cleaning up..." ;;
+        "normal") if [[ $e -eq 0 ]]; then __log "debug" "Script completed successfully, cleaning up..."; else __log "warning" "Script completed with non-zero exit code ($e), cleaning up..."; fi ;;
+    esac
+    return $e
+}
+
+__error() {
+    local e l c s x m f
+    e=$?; l=$1; c=$3; s=("${FUNCNAME[@]:-}")
+    [[ $e -eq 0 ]] && e=1
+    x=""; [[ ${#s[@]} -gt 1 ]] && x=" in function ${s[1]}()"
+    m=""; f="/tmp/compile_stderr_$$"
+    [[ -f "$f" ]] && m=$(tail -n 1 "$f" 2>/dev/null | sed 's/^.*: //')
+    __log "critical" "Script failed at line ${l}${x}"
+    __log "critical" "Command: ${c}"
+    [[ -n "$m" ]] && __log "critical" "Error: ${m}"
+    __log "critical" "Exit code: ${e}"
+    if [[ ${#s[@]} -gt 2 ]]; then
+        __log "critical" "Call stack:"; local i; for ((i=1; i<${#s[@]}; i++)); do __log "critical" "  $((i-1)): ${s[i]}()"; done
+    fi
+    trap - EXIT; __cleanup "error"; exit $e
+}
+
+__interrupt() {
+    local e
+    e=130
+    __log "warning" "Script interrupted by user (Ctrl+C)"
+    trap - EXIT; __cleanup "interrupt"
+    exit $e
+}
+
+__usage() {
+    local b r
+    if [[ "$AESCOMPILE_NO_COLOR" != "true" ]]; then b="$C_BOLD"; r="$C_RESET"; fi
+  cat << EOF
+${b}Usage:${r} $(basename "$0") [OPTIONS]
+${b}Description:${r}
+Compile Aseprite with Skia dependencies.
+${b}Options:${r}
+  ${b}-a, --aseprite-version${r} VERSION    Set Aseprite version (default: v1.3.15.2)
+  ${b}-s, --skia-version${r} VERSION        Set Skia version (default: aseprite-m124)
+  ${b}-d, --dependencies-dir${r} DIR        Set dependencies directory (default: /dependencies)
+  ${b}-o, --output-dir${r} DIR              Set output directory (default: /output)
+  ${b}-b, --build-type${r} TYPE             Set CMake build type: Release or RelWithDebInfo (default: RelWithDebInfo)
+  ${b}-v, --verbose${r}                     Increase verbosity level (can be used multiple times)
+                                    Levels: 0=critical, 1=error, 2=warning, 3=info, 4=debug
+  ${b}-q, --quiet${r}                       Suppress all output except errors and critical messages
+  ${b}-n, --no-color${r}                    Disable colored output
+  ${b}-h, --help${r}                        Display this help message
+${b}Examples:${r}
+  $(basename "$0") -a v1.3.15.2 -s aseprite-m124
+  $(basename "$0") --aseprite-version v1.3.10 --skia-version aseprite-m102
+  $(basename "$0") -d /custom/deps -o /custom/output
+  $(basename "$0") -b Release --no-color    # Release build without colors
+  $(basename "$0") -vv --no-color   # Very verbose without colors
+  $(basename "$0") -q               # Quiet mode
+EOF
+}
+
+__parse() {
+    local -a a=("$@"); for (( i=0; i<${#a[@]}; )); do
+        case ${a[i]} in
+            -a|--aseprite-version) AESCOMPILE_ASEPRITE_VERSION="${a[i+1]}"; i=$((i+2)) ;;
+            -s|--skia-version) AESCOMPILE_SKIA_VERSION="${a[i+1]}"; i=$((i+2)) ;;
+            -d|--dependencies-dir) AESCOMPILE_DEPENDENCIES_DIR="${a[i+1]}"; i=$((i+2)) ;;
+            -o|--output-dir) AESCOMPILE_OUTPUT_DIR="${a[i+1]}"; i=$((i+2)) ;;
+            -b|--build-type) AESCOMPILE_BUILD_TYPE="${a[i+1]}"; i=$((i+2)) ;;
+            -v|--verbose) ((AESCOMPILE_VERBOSITY++)); [[ $AESCOMPILE_VERBOSITY -gt 4 ]] && AESCOMPILE_VERBOSITY=4; i=$((i+1)) ;;
+            -q|--quiet) AESCOMPILE_QUIET=true; i=$((i+1)) ;;
+            -n|--no-color) AESCOMPILE_NO_COLOR=true; i=$((i+1)) ;;
+            -h|--help) __usage; exit 0 ;;
+            *) __log "error" "Unknown option: ${a[i]}"; __usage; exit 1 ;;
+        esac
+    done
+}
+
+exec 2> >(tee "/tmp/compile_stderr_$$" >/dev/null)
+trap '__error ${LINENO} ${BASH_LINENO} "$BASH_COMMAND"' ERR
+trap '__interrupt' INT TERM
+trap '__cleanup "normal"' EXIT
+
+# Main() ########################
+[[ ! "${BASH_SOURCE[0]}" == "${0}" ]] && return 0
+__parse "$@"
+__log "info" "Using Aseprite version: ${AESCOMPILE_ASEPRITE_VERSION}"
+__log "info" "Using Skia version: ${AESCOMPILE_SKIA_VERSION}"
+
+cd "${AESCOMPILE_DEPENDENCIES_DIR}"
+if [ ! -d "${AESCOMPILE_DEPENDENCIES_DIR}/depot_tools" ]; then
+    __log "info" "Cloning depot_tools"
+    __cmd git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+    cd depot_tools
+    __cmd git checkout main
+    cd ..
 else
-  cd depot_tools
-  echo "Checking out latest depot_tools"
-  git checkout main
-  git pull
-  cd ..
+    cd depot_tools
+    __log "info" "Checking out latest depot_tools"
+    __cmd git checkout main
+    __cmd git pull
+    cd ..
 fi
-
-export PATH="${PWD}/depot_tools:${PATH}"
-gclient
-
-if [ ! -d "/dependencies/skia" ]
-then
-  echo "Cloning skia"
-  git clone -b "${SKIA_VERSION}" https://github.com/aseprite/skia.git
+__add_path "${PWD}/depot_tools"
+__cmd gclient
+if [ ! -d "${AESCOMPILE_DEPENDENCIES_DIR}/skia" ]; then
+    __log "info" "Cloning skia"
+    __cmd git clone -b "${AESCOMPILE_SKIA_VERSION}" https://github.com/aseprite/skia.git
 else
-  echo "Updating to latest Skia version"
-  cd skia
-  git fetch
-  git checkout "${SKIA_VERSION}"
-  cd ..
+    __log "info" "Updating to latest Skia version"
+    cd skia
+    __cmd git fetch
+    __cmd git checkout "${AESCOMPILE_SKIA_VERSION}"
+    cd ..
 fi
-
 cd skia
-pwd
-echo "Syncing skia dependencies"
-python3 tools/git-sync-deps
-
-echo "Compiling skia"
-gn gen out/Release-x64 --args="is_debug=false is_official_build=true skia_use_system_expat=false skia_use_system_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false skia_use_sfntly=false skia_use_freetype=true skia_use_harfbuzz=true skia_pdf_subset_harfbuzz=true skia_use_system_freetype2=false skia_use_system_harfbuzz=false"
-ninja -C out/Release-x64 skia modules
-
-cd /output
-
-if [ ! -d "/output/aseprite" ]
-then
-  echo "Cloning Aseprite"
-  git clone -b "${ASEPRITE_VERSION}" --recursive https://github.com/aseprite/aseprite.git
+__log "debug" "Current directory: $(pwd)"
+__log "info" "Syncing skia dependencies"
+__cmd python3 tools/git-sync-deps
+__log "info" "Compiling skia"
+__cmd gn gen out/Release-x64 --args=\"is_debug=false is_official_build=true skia_use_system_expat=false skia_use_system_icu=false skia_use_system_libjpeg_turbo=false skia_use_system_libpng=false skia_use_system_libwebp=false skia_use_system_zlib=false skia_use_freetype=true skia_use_harfbuzz=true skia_pdf_subset_harfbuzz=true skia_use_system_freetype2=false skia_use_system_harfbuzz=false\"
+__cmd ninja -C out/Release-x64 skia modules
+cd "${AESCOMPILE_DEPENDENCIES_DIR}"
+if [ ! -d "${AESCOMPILE_DEPENDENCIES_DIR}/aseprite" ]; then
+    __log "info" "Cloning Aseprite"
+    __cmd git clone -b "${AESCOMPILE_ASEPRITE_VERSION}" --recursive https://github.com/aseprite/aseprite.git
 else
-  echo "Updating to latest Aseprite version"
-  cd aseprite
-  git fetch
-  git switch "${ASEPRITE_VERSION}" --detach
-  cd ..
+    __log "info" "Updating to latest Aseprite version"
+    cd aseprite
+    __cmd git fetch
+    __cmd git switch "${AESCOMPILE_ASEPRITE_VERSION}" --detach
+    cd ..
 fi
-
 cd aseprite
 mkdir -p build
 cd build
-
-echo "Compiling Asperite"
-cmake \
-  -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-  -DLAF_BACKEND=skia \
-  -DSKIA_DIR=/dependencies/skia \
-  -DSKIA_LIBRARY_DIR=/dependencies/skia/out/Release-x64 \
-  -DSKIA_LIBRARY=/dependencies/skia/out/Release-x64/libskia.a \
-  -G Ninja \
-  ..
-
-echo "Linking Aseprite"
-ninja aseprite
+__log "info" "Compiling Aseprite"
+OPENSSL_ROOT=$(__find_openssl) || OPENSSL_ROOT=""
+CMAKE_ARGS="-DCMAKE_BUILD_TYPE=${AESCOMPILE_BUILD_TYPE} -DLAF_BACKEND=skia -DSKIA_DIR=${AESCOMPILE_DEPENDENCIES_DIR}/skia -DSKIA_LIBRARY_DIR=${AESCOMPILE_DEPENDENCIES_DIR}/skia/out/Release-x64 -DSKIA_LIBRARY=${AESCOMPILE_DEPENDENCIES_DIR}/skia/out/Release-x64/libskia.a -G Ninja"
+[[ -n "$OPENSSL_ROOT" ]] && CMAKE_ARGS="$CMAKE_ARGS -DOPENSSL_ROOT_DIR=$OPENSSL_ROOT"
+__cmd cmake $CMAKE_ARGS ..
+__log "info" "Linking Aseprite"
+__cmd ninja aseprite
+__log "info" "Copying build results to output directory"
+mkdir -p "${AESCOMPILE_OUTPUT_DIR}"
+cp -r bin "${AESCOMPILE_OUTPUT_DIR}/" 2>/dev/null || cp aseprite "${AESCOMPILE_OUTPUT_DIR}/" 2>/dev/null || __log "warning" "Could not copy build results"
+__log "info" "Compilation completed successfully!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '2'
-
 services:
   installer:
-    build: .
+    build:
+      context: .
+      args:
+        - TZ=${TZ:-UTC}
+        - LANG=${LANG:-en_US.UTF-8}
     volumes:
     - "./output:/output:rw"
     - "./dependencies:/dependencies:rw"


### PR DESCRIPTION
This PR makes the following changes:

- Updated Dockerfile with updated slim trixie python base image and add build arguments/environment variable passthrough to compile.sh w/ more reasonably scoped build context.
- Updated compile.sh script with enhanced log streaming, no color, verbosity and quiet options, error, trap/break handling and cleanup, as well as get build working again.
- Fix for vscode:  Discard popup, created settings.json to configure SARIF viewer
- Move license from README.md to LICENSE file for standardized project licensing.
- Modified Makefile to add clean command to build fresh.
- Updated docker-compose.yml for better context and arguments.

With this, a working modern build of Aesprite on Linux is possible again.

**This PR has been tested for quality assurance (see https://github.com/nilsve/docker-aseprite-linux/pull/24#issuecomment-3536230466)**